### PR TITLE
optimized script by blocking unneeded requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,26 @@
 # Wordle Hack
+
 This is the first ever official hack in order to get answers to daily wordle answers.
 
 ## Prerequisites
 
- - Git 
- - Node.js
- - NO LIFE
+- Git
+- Node.js
+- NO LIFE
 
 ## How does this work?
+
 This program or hack scrapes the answers from the [this](https://www.nytimes.com/games/wordle/index.html) website (it is in it's localStorage)
-I feel bad for the developer of this website that they couldn't make it secure enough *wheezes*.
+I feel bad for the developer of this website that they couldn't make it secure enough _wheezes_.
 
 ## How do I use this?
+
 Install Git and Node.js
 
- - Then clone this repo
- - go to the directory and `npm install`
- - `node . ` or `node index.js`
+- Then clone this repo
+- go to the directory and `npm install`
+- `npm run start ` or `node .`
 
 ## Damn who made this?
-me. they call me ava-god-ox21 
 
- 
+me. they call me ava-god-ox21

--- a/index.js
+++ b/index.js
@@ -1,17 +1,40 @@
-const puppeteer = require("puppeteer");
+const puppeteer = require('puppeteer');
 
-async function nice(){
-	console.log("Get today's wordle answer")
-	const browser = await puppeteer.launch();
-	const page = await browser.newPage();
-	await page.goto("https://www.nytimes.com/games/wordle/index.html");
-	const localStorageData = await page.evaluate(()=>{
-		var newObj = localStorage.getItem("nyt-wordle-state");
-		var gg = JSON.parse(newObj);
-		return gg.solution;
-	});
-	console.log('\x1b[32m%s\x1b[0m', localStorageData);
-	await browser.close()
+async function nice() {
+  console.log("Get today's wordle answer");
+  console.time('timeToExecute');
+
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+
+  // Intercept requests from url
+  await page.setRequestInterception(true);
+
+  // If the page makes a request to a resource type of image, stylesheet or font then abort that request (we block the request)
+  page.on('request', (req) => {
+    if (
+      req.resourceType() === 'image' ||
+      req.resourceType() === 'stylesheet' ||
+      req.resourceType() === 'font'
+    ) {
+      req.abort();
+    } else {
+      req.continue();
+    }
+  });
+
+  await page.goto('https://www.nytimes.com/games/wordle/index.html');
+
+  // Fetch and parse the wordle answer
+  const localStorageData = await page.evaluate(() => {
+    var newObj = localStorage.getItem('nyt-wordle-state');
+    var gg = JSON.parse(newObj);
+    return gg.solution;
+  });
+
+  console.log('\x1b[32m%s\x1b[0m', localStorageData);
+  console.timeEnd('timeToExecute');
+  await browser.close();
 }
 
-nice()
+nice();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
In the image below I ran some tests to test how long the script takes to execute. By blocking unneeded resources such as images, stylesheets and fonts, the script executes in ~1 second. This works by intercepting these requests and blocking them. Fonts, stylesheets etc aren't required when trying to scrape localstorage. You can acutally optimize this further by blocking tracking scripts... 

[tests](https://ibb.co/XZh4vXM)